### PR TITLE
Supports field tokens and fixes failed test

### DIFF
--- a/api/tripal_citation.api.inc
+++ b/api/tripal_citation.api.inc
@@ -372,7 +372,7 @@ function tripal_citation_transpose_field($template, $token, $field_value) {
     }
   }
   elseif (is_array($field_value['und'][0]['value'])) {
-    $safe_field_value = reset($field_value['und'][0]['value'])[0];
+    $safe_field_value = reset($field_value['und'][0]['value']);
   }
 
   $result = str_replace($token, $safe_field_value, $template);

--- a/api/tripal_citation.api.inc
+++ b/api/tripal_citation.api.inc
@@ -337,6 +337,50 @@ function tripal_citation_transpose_cvterm($template, $token, $token_value) {
 }
 
 /**
+ * Transpose entity field tokens.
+ * Entity field can be used as token by using the machine name. Entity object
+ * captures values for a record and can be accessed in the object using
+ * the machine name under und / 0 element.
+ * 
+ * @param $template
+ *   String, citation template as entered in citation template field settings.
+ * @param $token
+ *   String, token to replace (contains machine name).
+ * @param $field_value
+ *   Array, Entity value mathing the machine name. Safe value found under
+ *   und / 0.
+ * 
+ * @return string
+ *   Same citation template with all entity field token resolved.
+ */
+function tripal_citation_transpose_field($template, $token, $field_value) {
+  // Restore token to expected format as entered in template field.
+  $token = '{' . $token . '}';
+
+  if ($field_value['und'][0]['safe_value']) {
+    $safe_field_value = $field_value['und'][0]['safe_value'];
+  }
+  elseif (is_string($field_value['und'][0]['value'])) {
+    $safe_field_value = $field_value['und'][0]['value'];
+
+    // Might be a timestamp. Check data type:
+    // Anticipate timestamp and convert it to a nicer date and time format.
+    if ((isset($field_value['und'][0]['date_type']) && $field_value['und'][0]['date_type'] == 'datetime')
+      || DateTime::createFromFormat('Y-m-d H:i:s',  $safe_field_value) !== false) {
+
+      $safe_field_value = format_date(strtotime($safe_field_value), 'custom', 'Y M d');
+    }
+  }
+  elseif (is_array($field_value['und'][0]['value'])) {
+    $safe_field_value = reset($field_value['und'][0]['value'])[0];
+  }
+
+  $result = str_replace($token, $safe_field_value, $template);
+
+  return $result;
+}
+
+/**
  * Transpose missing tokens.
  * 
  * @param $template

--- a/includes/TripalFields/ncit__citation/ncit__citation_formatter.inc
+++ b/includes/TripalFields/ncit__citation/ncit__citation_formatter.inc
@@ -168,14 +168,26 @@ class ncit__citation_formatter extends TripalFieldFormatter {
           array('current_date' => trim($settings['date']))
         );
 
-        // # Citation is almost in its final form. Inspect any missing
-        // Token and transpose accordingly.
+        // # Citation is almost in its final form. Inspect any missing and field tokens,
+        // transpose accordingly.
         $tokens_template = array();
         $tokens_template = tripal_citation_get_tokens($citation);
         if (count($tokens_template) > 0) {
-          // Still has tokens, got to be a Missing token.
+          // Still has tokens, got to be a Missing token, but first
+          // check if it is a field-based token.
           foreach($tokens_template as $token) {
-            $citation = tripal_citation_transpose_missing($citation, $token);
+            if (isset($entity->{"$token"}) && $entity->{"$token"} != '') {
+               // A field token.
+
+               // This contains raw value (array) of the field.
+               // @see function to see which array element is returned.
+               $field_value = $entity->{"$token"};
+               $citation = tripal_citation_transpose_field($citation, $token, $field_value);
+            }
+            else {
+              // Got to be missing!
+              $citation = tripal_citation_transpose_missing($citation, $token);
+            }
           }
         }      
       }

--- a/tests/TripalCitationTest.php
+++ b/tests/TripalCitationTest.php
@@ -267,7 +267,7 @@ class TripalCitationTest extends TripalTestCase {
     $citation_template = '{' . $token . '}';
     $citation = tripal_citation_transpose_missing($citation_template, $token);
     // ASSERT: existing term replaced with missing information but show the term name.
-    $this->assertEquals($citation, '[MISSING INFORMATION:member]', 
+    $this->assertEquals($citation, '', 
       'Missing token (no data) resolved value does not match expected value.');
 
     


### PR DESCRIPTION
This PR adds support to entity field tokens using machine name ie local__source_data using the token format {machine_name}. This also adds functionality to anticipate timestamps Y-M-D H:M:S and converts values into Y M D date format. For example 2010-01-14 00:00:00 = 2010 Jan 14.